### PR TITLE
Fixed 'oc' location discovery on mac

### DIFF
--- a/tasks/login-to-cluster.yml
+++ b/tasks/login-to-cluster.yml
@@ -17,7 +17,7 @@
 
 - name: set oc location
   set_fact:
-    oc_location: "{{ oc_location_result.stdout  | map('trim')}}"
+    oc_location: "{{ oc_location_result.stdout  | trim() }}"
   when: ansible_distribution == 'MacOSX'
 
 - name: login as super user with token on OpenShift 4


### PR DESCRIPTION
This PR fixes the issue with `oc` discovery on MacOS platform

## Problem description
Path to `oc` binary is converted from a string to a list, which causes problem below
```bash
TASK [tosin2013.quarkus_cafe_demo_role : login as super user with token on OpenShift 4] ****************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "'[/,' u, s, r, /, l, o, c, a, l, /, b, i, n, /, o, 'c]' login --token=XXXX --server=https://XXXX --insecure-skip-tls-verify=True", "msg": "[Errno 2] No such file or directory: b'[/,'", "rc": 2}
```