### PR TITLE
Make sure we always create the project_namespace

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
 
     - name: Create Quarkus project 
       include_tasks: create-project.yml
+      tags: always
 
     - name: AMQ Streams installation
       include_tasks: amq-streams-install.yml


### PR DESCRIPTION
Without this change, if the project was not existing yet, we could error
out with:
FAILED - RETRYING: Wait for AMQ CRD to be ready

Since it was waiting for AMQ in a namespace that was not existing.

Signed-off-by: Michele Baldessari <michele@acksyn.org>